### PR TITLE
🐛 Do not disable Redis API when we are destroying instance of this mo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [v1.3.0] - 2020-08-13
+### Changed
+- Do not disable Redis API when the module's instance is destroyed
+
 ## [v1.2.0] - 2020-08-13
 ### Changed
 - Change K8s stateful set's name to contain `instance_name` postfix to support more Redis instances in one GCP project

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,9 @@ data "google_compute_network" "default" {
 }
 
 resource "google_project_service" "redis" {
-  project = var.project
-  service = "redis.googleapis.com"
+  project            = var.project
+  service            = "redis.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_redis_instance" "redis" {


### PR DESCRIPTION
…dule, because we can have more instances which needs it enabled